### PR TITLE
made the indirect task `ProcessPatternMapping` to a proper task.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 }
 
 group = "com.github.SkyHanniStudios"
-version = "1.0.0"
+version = "1.0.1"
 val githubProjectName = "SkyHanni-Preprocessor"
 
 kotlin {

--- a/src/main/kotlin/com/replaymod/gradle/preprocess/ProcessPatternMappings.kt
+++ b/src/main/kotlin/com/replaymod/gradle/preprocess/ProcessPatternMappings.kt
@@ -1,0 +1,74 @@
+package com.replaymod.gradle.preprocess
+
+import com.replaymod.gradle.remap.PatternMapping
+import org.gradle.api.DefaultTask
+import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.model.ObjectFactory
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputFile
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+import java.io.FileOutputStream
+import java.io.ObjectOutputStream
+import javax.inject.Inject
+
+abstract class ProcessPatternMappings @Inject constructor(objects: ObjectFactory) : DefaultTask() {
+
+    @get:InputFile
+    @get:Optional
+    var mappingFile: File? = null
+
+    @get:InputFile
+    @get:Optional
+    var patternMappings: File? = null
+
+    @get:OutputFile
+    val destination: RegularFileProperty = objects.fileProperty()
+
+    @Internal
+    val patternMappingsList = mutableListOf<PatternMapping>()
+
+    @get:OutputFile
+    val patternMappingsJson: RegularFileProperty = objects.fileProperty()
+
+    @TaskAction
+    fun processPatternMappings() {
+        val mappingFile = mappingFile
+        val patternMappings = patternMappings
+        val tempMappingFile = destination.get().asFile
+        val patternMappingsJson = patternMappingsJson.get().asFile
+        if(mappingFile == null){
+            tempMappingFile.writeText("")
+            patternMappingsJson.writeText("")
+            return
+        }
+        if (patternMappings == null) {
+            mappingFile.copyTo(tempMappingFile,overwrite = true)
+            patternMappingsJson.writeText("")
+            return
+        }
+        tempMappingFile.writeText(mappingFile.readText())
+
+        for (line in patternMappings.readLines()) {
+            if (line.trim { it <= ' ' }.startsWith("#") || line.trim { it <= ' ' }.isEmpty()) continue
+
+            val parts = line.split(" ".toRegex()).dropLastWhile { it.isEmpty() }.toTypedArray()
+
+            require(parts.size == 5)
+
+            val patternMapping = PatternMapping(parts[0], parts[1], parts[2], parts[3], parts[4])
+            val classMapping = "${patternMapping.newClass} ${patternMapping.oldClass}"
+            val methodMapping = "${patternMapping.newClass} ${patternMapping.newMethod} ${patternMapping.oldMethod}"
+
+            tempMappingFile.appendText("\n$classMapping\n$methodMapping")
+            patternMappingsList.add(patternMapping)
+        }
+
+        val out = patternMappingsJson
+        ObjectOutputStream(FileOutputStream(out)).use {
+            it.writeObject(patternMappingsList)
+        }
+    }
+}


### PR DESCRIPTION
Made the scuffed process mapping "task" a real task.

<details>
<Summary>Error this fixes</Summary>

```
Caused by: java.io.FileNotFoundException: /home/runner/work/SkyHanni/SkyHanni/versions/1.21.5/build/tempMapping.txt (No such file or directory)
	at kotlin.io.FilesKt__FileReadWriteKt.writeText(FileReadWrite.kt:141)
	at kotlin.io.FilesKt__FileReadWriteKt.writeText$default(FileReadWrite.kt:140)
	at com.replaymod.gradle.preprocess.PreprocessPlugin.processPatternMappings(PreprocessPlugin.kt:47)
	at com.replaymod.gradle.preprocess.PreprocessPlugin.access$processPatternMappings(PreprocessPlugin.kt:32)
	at com.replaymod.gradle.preprocess.PreprocessPlugin$apply$3$preprocessCode$1.invoke(PreprocessPlugin.kt:148)
	at com.replaymod.gradle.preprocess.PreprocessPlugin$apply$3$preprocessCode$1.invoke(PreprocessPlugin.kt:127)
	at com.replaymod.gradle.preprocess.PreprocessPlugin$apply$3$inlined$sam$i$org_gradle_api_Action$0.execute(TaskContainerExtensions.kt)
	at org.gradle.api.internal.DefaultMutationGuard$1.execute(DefaultMutationGuard.java:66)
	at org.gradle.api.internal.DefaultMutationGuard$1.execute(DefaultMutationGuard.java:66)
	at org.gradle.internal.code.DefaultUserCodeApplicationContext$CurrentApplication$1.execute(DefaultUserCodeApplicationContext.java:124)
	at org.gradle.api.internal.DefaultCollectionCallbackActionDecorator$BuildOperationEmittingAction$1.run(DefaultCollectionCallbackActionDecorator.java:110)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$1.execute(DefaultBuildOperationRunner.java:30)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$1.execute(DefaultBuildOperationRunner.java:27)
	at org.gradle.internal.operations.DefaultBuildOperationRunner$2.execute(DefaultBuildOperationRunner.java:67)
	... 258 more
```

https://github.com/hannibal002/SkyHanni/actions/runs/16747339999/job/47408930232

</details>