### PR TITLE
Fix path delimiter on non-Windows platforms

### DIFF
--- a/src/main/kotlin/com/replaymod/gradle/preprocess/PreprocessTask.kt
+++ b/src/main/kotlin/com/replaymod/gradle/preprocess/PreprocessTask.kt
@@ -11,23 +11,9 @@ import net.fabricmc.mappingio.tree.MemoryMappingTree
 import org.cadixdev.lorenz.MappingSet
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
-import org.gradle.api.file.ConfigurableFileCollection
-import org.gradle.api.file.FileCollection
-import org.gradle.api.file.FileSystemOperations
-import org.gradle.api.file.ProjectLayout
-import org.gradle.api.file.RegularFileProperty
+import org.gradle.api.file.*
 import org.gradle.api.model.ObjectFactory
-import org.gradle.api.tasks.CacheableTask
-import org.gradle.api.tasks.Input
-import org.gradle.api.tasks.InputDirectory
-import org.gradle.api.tasks.InputFile
-import org.gradle.api.tasks.InputFiles
-import org.gradle.api.tasks.Internal
-import org.gradle.api.tasks.Optional
-import org.gradle.api.tasks.OutputDirectories
-import org.gradle.api.tasks.PathSensitive
-import org.gradle.api.tasks.PathSensitivity
-import org.gradle.api.tasks.TaskAction
+import org.gradle.api.tasks.*
 import org.gradle.kotlin.dsl.mapProperty
 import org.gradle.kotlin.dsl.property
 import org.gradle.work.ChangeType
@@ -46,12 +32,7 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.regex.Pattern
 import javax.inject.Inject
-import kotlin.io.path.extension
-import kotlin.io.path.isDirectory
-import kotlin.io.path.isRegularFile
-import kotlin.io.path.pathString
-import kotlin.io.path.readLines
-import kotlin.io.path.readText
+import kotlin.io.path.*
 
 data class Keywords(
     val disableRemap: String,
@@ -63,8 +44,6 @@ data class Keywords(
     val endif: String,
     val eval: String,
 ) : Serializable
-
-private val pathDelimiter = Paths.get("\\").pathString
 
 @CacheableTask
 open class PreprocessTask @Inject constructor(
@@ -266,7 +245,7 @@ open class PreprocessTask @Inject constructor(
 
                 Files.walk(path).filter { Files.isDirectory(it) }.filter { it.endsWith(convertedCompanyName) }
                     .findFirst().orElse(null)?.let {
-                        path.relativize(it).pathString + pathDelimiter
+                        path.relativize(it).pathString + File.separator
                     } ?: run {
                     logger.error("Failed to find walkDown of '$convertedCompanyName' in entry '${entry.outBase}'")
                     ""
@@ -285,7 +264,7 @@ open class PreprocessTask @Inject constructor(
         preprocess(mapping, sourceFiles, dependencies)
     }
 
-    private fun String.convertedDotToPath(): String = Paths.get(replace('.', '\\')).pathString
+    private fun String.convertedDotToPath(): String = Paths.get(replace('.', File.separatorChar)).pathString
 
     fun preprocessAll(mapping: File?, entries: List<InOut>) {
 
@@ -369,7 +348,7 @@ open class PreprocessTask @Inject constructor(
             return listOf(".kt", ".java").map {
                 outBase.resolve(combi.pathString + it)
             }.firstOrNull { it.isRegularFile() }
-                ?: findFirstDirOrFileUnderOut(prefix, fileLocation.substringBeforeLast(pathDelimiter, ""))
+                ?: findFirstDirOrFileUnderOut(prefix, fileLocation.substringBeforeLast(File.separator, ""))
         }
 
         fun findFirstDirOrFileUnderIn(prefix: String, fileLocation: String): Path {
@@ -381,7 +360,7 @@ open class PreprocessTask @Inject constructor(
             return listOf(".kt", ".java").map {
                 inBase.resolve(combi.pathString + it)
             }.firstOrNull { it.isRegularFile() }
-                ?: findFirstDirOrFileUnderIn(prefix, fileLocation.substringBeforeLast(pathDelimiter, ""))
+                ?: findFirstDirOrFileUnderIn(prefix, fileLocation.substringBeforeLast(File.separator, ""))
         }
     }
 

--- a/src/main/kotlin/com/replaymod/gradle/preprocess/PreprocessTask.kt
+++ b/src/main/kotlin/com/replaymod/gradle/preprocess/PreprocessTask.kt
@@ -11,9 +11,23 @@ import net.fabricmc.mappingio.tree.MemoryMappingTree
 import org.cadixdev.lorenz.MappingSet
 import org.gradle.api.DefaultTask
 import org.gradle.api.GradleException
-import org.gradle.api.file.*
+import org.gradle.api.file.ConfigurableFileCollection
+import org.gradle.api.file.FileCollection
+import org.gradle.api.file.FileSystemOperations
+import org.gradle.api.file.ProjectLayout
+import org.gradle.api.file.RegularFileProperty
 import org.gradle.api.model.ObjectFactory
-import org.gradle.api.tasks.*
+import org.gradle.api.tasks.CacheableTask
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.InputDirectory
+import org.gradle.api.tasks.InputFile
+import org.gradle.api.tasks.InputFiles
+import org.gradle.api.tasks.Internal
+import org.gradle.api.tasks.Optional
+import org.gradle.api.tasks.OutputDirectories
+import org.gradle.api.tasks.PathSensitive
+import org.gradle.api.tasks.PathSensitivity
+import org.gradle.api.tasks.TaskAction
 import org.gradle.kotlin.dsl.mapProperty
 import org.gradle.kotlin.dsl.property
 import org.gradle.work.ChangeType
@@ -32,7 +46,12 @@ import java.nio.file.Path
 import java.nio.file.Paths
 import java.util.regex.Pattern
 import javax.inject.Inject
-import kotlin.io.path.*
+import kotlin.io.path.extension
+import kotlin.io.path.isDirectory
+import kotlin.io.path.isRegularFile
+import kotlin.io.path.pathString
+import kotlin.io.path.readLines
+import kotlin.io.path.readText
 
 data class Keywords(
     val disableRemap: String,


### PR DESCRIPTION
Fixes incremental preprocessor being broken on non-Windows platforms due to hardcoded Windows-specific path delimiters.

<details>
<summary>Logs of error on macOS without this PR</summary>

```
0:06:12: Executing 'assemble'…

> Task :sharedVariables:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :sharedVariables:compileKotlin UP-TO-DATE
> Task :sharedVariables:compileJava NO-SOURCE
> Task :sharedVariables:pluginDescriptors UP-TO-DATE
> Task :sharedVariables:processResources UP-TO-DATE
> Task :sharedVariables:classes UP-TO-DATE
> Task :sharedVariables:jar UP-TO-DATE
SkyHanni multi version stage loaded: FULL
> Task :buildSrc:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :buildSrc:compileKotlin UP-TO-DATE
> Task :buildSrc:compileJava NO-SOURCE
> Task :buildSrc:compileGroovy NO-SOURCE
> Task :buildSrc:pluginDescriptors UP-TO-DATE
> Task :buildSrc:processResources NO-SOURCE
> Task :buildSrc:classes UP-TO-DATE
> Task :buildSrc:jar UP-TO-DATE

> Configure project :
Preprocessor 1.0.6
Loading mappings from /Users/luna/src/SkyHanni/versions/mapping-1.16.5-forge-1.8.9.txt
Loading pattern mappings from /Users/luna/src/SkyHanni/versions/pattern-mappings-1.16.5-forge-1.8.9.txt
Loading mappings from /Users/luna/src/SkyHanni/versions/mapping-1.16.5-fabric-1.16.5-forge.txt
Skipped loading pattern mappings from /Users/luna/src/SkyHanni/versions/pattern-mappings-1.16.5-fabric-1.16.5-forge.txt
Loading mappings from /Users/luna/src/SkyHanni/versions/mapping-1.21.5-1.16.5-fabric.txt
Loading pattern mappings from /Users/luna/src/SkyHanni/versions/pattern-mappings-1.21.5-1.16.5-fabric.txt
Loading mappings from /Users/luna/src/SkyHanni/versions/mapping-1.21.7-1.21.5.txt
Skipped loading pattern mappings from /Users/luna/src/SkyHanni/versions/pattern-mappings-1.21.7-1.21.5.txt

> Configure project :1.8.9
Not publishing sources jar as it was not created by the java plugin. Use java.withSourcesJar() to fix.

> Configure project :1.16.5-forge
Not publishing sources jar as it was not created by the java plugin. Use java.withSourcesJar() to fix.
Legacy extra mappings are deprecated. Please consider enabling strict extra mappings via `preprocess.strictExtraMappings.set(true)` in your root project. You may suppress this message by explicitly setting it to `false`.

> Configure project :1.16.5-fabric
Essential Loom: 1.10.34
Not publishing sources jar as it was not created by the java plugin. Use java.withSourcesJar() to fix.
Legacy extra mappings are deprecated. Please consider enabling strict extra mappings via `preprocess.strictExtraMappings.set(true)` in your root project. You may suppress this message by explicitly setting it to `false`.

> Configure project :1.21.5
Not publishing sources jar as it was not created by the java plugin. Use java.withSourcesJar() to fix.
Legacy extra mappings are deprecated. Please consider enabling strict extra mappings via `preprocess.strictExtraMappings.set(true)` in your root project. You may suppress this message by explicitly setting it to `false`.

> Configure project :1.21.7
Not publishing sources jar as it was not created by the java plugin. Use java.withSourcesJar() to fix.
Legacy extra mappings are deprecated. Please consider enabling strict extra mappings via `preprocess.strictExtraMappings.set(true)` in your root project. You may suppress this message by explicitly setting it to `false`.

> Task :1.21.5:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :annotation-processors:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :1.8.9:includeBackupNeuRepo UP-TO-DATE
> Task :1.16.5-forge:createPatternMappings UP-TO-DATE
> Task :1.21.5:createPatternMappings UP-TO-DATE
> Task :1.16.5-fabric:createPatternMappings UP-TO-DATE
> Task :1.8.9:includeBackupRepo UP-TO-DATE
> Task :1.21.5:includeBackupNeuRepo UP-TO-DATE
> Task :1.8.9:checkKotlinGradlePluginConfigurationErrors SKIPPED
> Task :1.21.5:includeBackupRepo UP-TO-DATE
> Task :1.16.5-forge:preprocessResources UP-TO-DATE
> Task :1.21.5:processIncludeJars UP-TO-DATE
> Task :1.16.5-fabric:preprocessResources UP-TO-DATE
> Task :1.21.5:preprocessResources UP-TO-DATE
> Task :annotation-processors:compileKotlin UP-TO-DATE
> Task :annotation-processors:compileJava NO-SOURCE
> Task :annotation-processors:processResources UP-TO-DATE
> Task :annotation-processors:classes UP-TO-DATE
> Task :annotation-processors:jar UP-TO-DATE
> Task :1.16.5-forge:preprocessTestCode UP-TO-DATE
> Task :1.16.5-fabric:preprocessTestCode UP-TO-DATE
> Task :1.21.5:preprocessTestCode UP-TO-DATE
> Task :1.8.9:kspKotlin
w: ATTENTION!
This build uses unsafe internal compiler arguments:

-XXLanguage:+BreakContinueInInlineLambdas

This mode is not recommended for production use,
as no stability/compatibility guarantees are given on
compiler or generated code. Use it at your own risk!

w: [ksp] Generated VersionConstants file with mod version 4.18.0 and mc version 1.8.9
w: [ksp] Generated GeneratedEventPrimaryFunctionNames with 12 entries
w: [ksp] Found 774 symbols with @SkyHanniModule for mc 1.8.9
w: [ksp] Generated LoadedModules file with 774 modules

> Task :1.8.9:processResources UP-TO-DATE

> Task :1.16.5-forge:preprocessCode FAILED
Incremental Preprocess run with 1 changes
Failed to find walkDown of 'at\hannibal2\skyhanni' in entry '/Users/luna/src/SkyHanni/versions/1.16.5-forge/build/preprocessed/main/java'

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':1.16.5-forge:preprocessCode'.
> java.nio.file.NoSuchFileException: /Users/luna/src/SkyHanni/versions/1.16.5-forge/src/main/java/features\misc\compacttablist

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.
> Get more help at https://help.gradle.org.

BUILD FAILED in 42s
27 actionable tasks: 2 executed, 25 up-to-date
0:06:55: Execution finished 'assemble'.
```
</details>