### PR TITLE
Fixed "closing window" issue for Intelji

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
 }
 
 group = "com.github.SkyHanniStudios"
-version = "1.0.7"
+version = "1.0.8"
 val githubProjectName = "SkyHanni-Preprocessor"
 
 kotlin {


### PR DESCRIPTION
Moved the delete directly before the write/copy instructions the same way the old code was. I need to pass the a lambda though as full and incremental runs delete completely different files.